### PR TITLE
fix: disable Arrow by default in the JDBC driver

### DIFF
--- a/src/main/java/io/kestra/plugin/databricks/sql/Query.java
+++ b/src/main/java/io/kestra/plugin/databricks/sql/Query.java
@@ -68,6 +68,8 @@ import jakarta.validation.constraints.NotNull;
     description = """
         See [Retrieve the connection details](https://docs.databricks.com/integrations/jdbc-odbc-bi.html#retrieve-the-connection-details) in the Databricks documentation to discover how to retrieve the needed configuration properties.
         We're using the Databricks JDBC driver to execute a Query, see [https://docs.databricks.com/integrations/jdbc-odbc-bi.html#jdbc-driver-capabilities](https://docs.databricks.com/integrations/jdbc-odbc-bi.html#jdbc-driver-capabilities) for its capabilities.
+        
+        Due to current limitation of the JDBC driver with Java 21, Arrow is disabled, performance may be impacted, see [here](https://community.databricks.com/t5/data-engineering/what-s-the-eta-for-supporting-java-21-in-the-jdbc-driver/td-p/57370) and [here](https://community.databricks.com/t5/data-engineering/java-21-support-with-databricks-jdbc-driver/m-p/49297) fro Databricks status on Java 21 support.
         """
 )
 public class Query extends Task implements RunnableTask<Query.Output> {
@@ -127,6 +129,12 @@ public class Query extends Task implements RunnableTask<Query.Output> {
         }
         if (properties != null) {
             props.putAll(properties);
+        }
+        // see https://community.databricks.com/t5/data-engineering/what-s-the-eta-for-supporting-java-21-in-the-jdbc-driver/td-p/57370 and https://community.databricks.com/t5/data-engineering/java-21-support-with-databricks-jdbc-driver/m-p/49297
+        // the JDBC driver is not compatible with Java 21 due to using a very old Arrow library
+        // as long as it's the case, we disable arrow by default (except if someone already set the 'EnableArrow' property
+        if (!props.contains("EnableArrow")) {
+            props.put("EnableArrow", "0");
         }
         runContext.logger().debug("Using JDBC URL: {}", url);
 


### PR DESCRIPTION
This is unfortunate but is the only solution as it uses and old version of Arrow not compatible with Java 21. 

See https://community.databricks.com/t5/data-engineering/what-s-the-eta-for-supporting-java-21-in-the-jdbc-driver/td-p/57370
See https://community.databricks.com/t5/data-engineering/java-21-support-with-databricks-jdbc-driver/m-p/49297

Fixes #69