### PR TITLE
fix(plugin-databricks-1): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/databricks/cli/package-info.java
+++ b/src/main/java/io/kestra/plugin/databricks/cli/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "CLI",
+    title = "Databricks CLI",
     description = "This sub-group of plugins contains tasks for executing Databricks SQL CLI commands.",
     categories = { PluginSubGroup.PluginCategory.DATA }
 )

--- a/src/main/java/io/kestra/plugin/databricks/cluster/package-info.java
+++ b/src/main/java/io/kestra/plugin/databricks/cluster/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Cluster",
+    title = "Databricks Cluster",
     description = "This sub-group of plugins contains tasks for managing Databricks clusters.",
     categories = { PluginSubGroup.PluginCategory.DATA }
 )

--- a/src/main/java/io/kestra/plugin/databricks/job/package-info.java
+++ b/src/main/java/io/kestra/plugin/databricks/job/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Job",
+    title = "Databricks Job",
     description = "This sub-group of plugins contains tasks for launching jobs on a Databricks cluster.",
     categories = { PluginSubGroup.PluginCategory.DATA }
 )

--- a/src/main/java/io/kestra/plugin/databricks/sql/package-info.java
+++ b/src/main/java/io/kestra/plugin/databricks/sql/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "SQL",
+    title = "Databricks SQL",
     description = "This sub-group of plugins contains tasks for executing SQL queries on a Databricks cluster.",
     categories = { PluginSubGroup.PluginCategory.DATA }
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge