### PR TITLE
feat(cli): add OAuth M2M service principal auth to DatabricksCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,35 @@
 - Provides plugin components under `io.kestra.plugin.databricks`.
 - Includes classes such as `DeleteCluster`, `CreateCluster`, `CreateJob`, `SubmitRun`.
 
+## DatabricksCLI — Authentication
+
+`DatabricksCLI` supports two mutually exclusive authentication modes. `databricksToken` takes precedence when both are provided.
+
+**PAT (personal access token)**
+
+```yaml
+tasks:
+  - id: list_clusters
+    type: io.kestra.plugin.databricks.cli.DatabricksCLI
+    databricksHost: "{{ secret('DATABRICKS_HOST') }}"
+    databricksToken: "{{ secret('DATABRICKS_TOKEN') }}"
+    commands:
+      - databricks clusters list
+```
+
+**OAuth M2M (service principal)**
+
+```yaml
+tasks:
+  - id: list_clusters
+    type: io.kestra.plugin.databricks.cli.DatabricksCLI
+    databricksHost: "{{ secret('DATABRICKS_HOST') }}"
+    clientId: "{{ secret('DATABRICKS_CLIENT_ID') }}"
+    clientSecret: "{{ secret('DATABRICKS_CLIENT_SECRET') }}"
+    commands:
+      - databricks clusters list
+```
+
 ## Documentation
 * Full documentation can be found under [kestra.io/docs](https://kestra.io/docs)
 * Documentation for developing a plugin is included in the [Plugin Developer Guide](https://kestra.io/docs/plugin-developer-guide/).

--- a/src/main/java/io/kestra/plugin/databricks/cli/DatabricksCLI.java
+++ b/src/main/java/io/kestra/plugin/databricks/cli/DatabricksCLI.java
@@ -120,7 +120,7 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
         title = "OAuth M2M client ID",
         description = "Service principal client ID; exported to DATABRICKS_CLIENT_ID. Use with `clientSecret` as an alternative to `databricksToken`."
     )
-    @PluginProperty(group = "main")
+    @PluginProperty(secret = true, group = "main")
     protected Property<String> clientId;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/databricks/cli/DatabricksCLI.java
+++ b/src/main/java/io/kestra/plugin/databricks/cli/DatabricksCLI.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.TargetOS;
@@ -17,7 +18,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @Getter
@@ -28,7 +28,8 @@ import io.kestra.core.models.annotations.PluginProperty;
     title = "Run Databricks CLI commands",
     description = """
         Executes Databricks CLI statements inside the official CLI container (default `ghcr.io/databricks/cli:latest`).
-        Injects DATABRICKS_HOST and DATABRICKS_TOKEN as environment variables for each command.
+        Supports two authentication modes: PAT (via `databricksToken`) or OAuth M2M service principal
+        (via `clientId` + `clientSecret`). When `databricksToken` is set it always takes precedence.
         """
 )
 @Plugin(
@@ -68,6 +69,23 @@ import io.kestra.core.models.annotations.PluginProperty;
                     commands:
                       - databricks jobs run-now {{ inputs.jobId }} > files.txt
                 """
+        ),
+        @Example(
+            full = true,
+            title = "List Databricks clusters using OAuth M2M service principal",
+            code = """
+                id: databricks_cli_oauth
+                namespace: company.team
+
+                tasks:
+                  - id: list_clusters
+                    type: io.kestra.plugin.databricks.cli.DatabricksCLI
+                    databricksHost: "{{ secret('DATABRICKS_HOST') }}"
+                    clientId: "{{ secret('DATABRICKS_CLIENT_ID') }}"
+                    clientSecret: "{{ secret('DATABRICKS_CLIENT_SECRET') }}"
+                    commands:
+                      - databricks clusters list
+                """
         )
     }
 )
@@ -78,7 +96,7 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
     @PluginProperty(group = "execution")
     protected Property<String> containerImage = Property.ofValue(DEFAULT_IMAGE);
 
-    @Schema(title = "CLI commands to execute", description = "Commands run sequentially with host/token pre-set in the environment")
+    @Schema(title = "CLI commands to execute", description = "Commands run sequentially with host and auth vars pre-set in the environment")
     @NotNull
     @PluginProperty(group = "main")
     protected Property<List<String>> commands;
@@ -88,10 +106,29 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
     @PluginProperty(group = "main")
     protected Property<String> databricksHost;
 
-    @Schema(title = "Databricks personal access token", description = "PAT exported to DATABRICKS_TOKEN for each command; render from secrets")
-    @NotNull
+    @Schema(
+        title = "Databricks personal access token",
+        description = """
+            PAT exported to DATABRICKS_TOKEN for each command; render from secrets.
+            Use this for PAT-based auth. Takes precedence over `clientId`/`clientSecret` when both are set.
+            """
+    )
     @PluginProperty(secret = true, group = "main")
     protected Property<String> databricksToken;
+
+    @Schema(
+        title = "OAuth M2M client ID",
+        description = "Service principal client ID; exported to DATABRICKS_CLIENT_ID. Use with `clientSecret` as an alternative to `databricksToken`."
+    )
+    @PluginProperty(group = "main")
+    protected Property<String> clientId;
+
+    @Schema(
+        title = "OAuth M2M client secret",
+        description = "Service principal secret; exported to DATABRICKS_CLIENT_SECRET. Render from secrets."
+    )
+    @PluginProperty(secret = true, group = "main")
+    protected Property<String> clientSecret;
 
     @Override
     protected DockerOptions injectDefaults(RunContext runContext, DockerOptions original) throws IllegalVariableEvaluationException {
@@ -105,15 +142,19 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        TargetOS os = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
+        var os = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
 
-        String host = runContext.render(databricksHost).as(String.class).orElseThrow();
-        String token = runContext.render(databricksToken).as(String.class).orElseThrow();
+        var host = runContext.render(databricksHost).as(String.class).orElseThrow();
+        var rToken = runContext.render(databricksToken).as(String.class).orElse(null);
+        var rClientId = runContext.render(clientId).as(String.class).orElse(null);
+        var rClientSecret = runContext.render(clientSecret).as(String.class).orElse(null);
 
-        List<String> envCommands = runContext.render(commands)
+        var envPrefix = buildEnvPrefix(host, rToken, rClientId, rClientSecret);
+
+        var envCommands = runContext.render(commands)
             .asList(String.class)
             .stream()
-            .map(cmd -> String.format("DATABRICKS_HOST=%s DATABRICKS_TOKEN=%s %s", host, token, cmd))
+            .map(cmd -> envPrefix + " " + cmd)
             .toList();
 
         return this.commands(runContext)
@@ -123,5 +164,15 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
             .withCommands(Property.ofValue(envCommands))
             .withTargetOS(os)
             .run();
+    }
+
+    String buildEnvPrefix(String host, String token, String clientId, String clientSecret) {
+        if (token != null) {
+            return String.format("DATABRICKS_HOST=%s DATABRICKS_TOKEN=%s", host, token);
+        } else if (clientId != null && clientSecret != null) {
+            return String.format("DATABRICKS_HOST=%s DATABRICKS_CLIENT_ID=%s DATABRICKS_CLIENT_SECRET=%s", host, clientId, clientSecret);
+        }
+        throw new IllegalArgumentException(
+            "DatabricksCLI requires authentication: set `databricksToken` (PAT) or both `clientId` and `clientSecret` (OAuth M2M).");
     }
 }

--- a/src/main/java/io/kestra/plugin/databricks/cli/DatabricksCLI.java
+++ b/src/main/java/io/kestra/plugin/databricks/cli/DatabricksCLI.java
@@ -142,14 +142,14 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
 
     @Override
     public ScriptOutput run(RunContext runContext) throws Exception {
-        var os = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
+        var rOs = runContext.render(this.targetOS).as(TargetOS.class).orElse(null);
 
-        var host = runContext.render(databricksHost).as(String.class).orElseThrow();
+        var rHost = runContext.render(databricksHost).as(String.class).orElseThrow();
         var rToken = runContext.render(databricksToken).as(String.class).orElse(null);
         var rClientId = runContext.render(clientId).as(String.class).orElse(null);
         var rClientSecret = runContext.render(clientSecret).as(String.class).orElse(null);
 
-        var envPrefix = buildEnvPrefix(host, rToken, rClientId, rClientSecret);
+        var envPrefix = buildEnvPrefix(rHost, rToken, rClientId, rClientSecret);
 
         var envCommands = runContext.render(commands)
             .asList(String.class)
@@ -162,7 +162,7 @@ public class DatabricksCLI extends AbstractExecScript implements RunnableTask<Sc
             .withBeforeCommands(beforeCommands)
             .withBeforeCommandsWithOptions(true)
             .withCommands(Property.ofValue(envCommands))
-            .withTargetOS(os)
+            .withTargetOS(rOs)
             .run();
     }
 

--- a/src/test/java/io/kestra/plugin/databricks/cli/DatabricksCLITest.java
+++ b/src/test/java/io/kestra/plugin/databricks/cli/DatabricksCLITest.java
@@ -18,19 +18,20 @@ import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
-@DisabledIf(
-    value = "canNotBeEnabled",
-    disabledReason = "Disabled for CI/CD as requires secrets data: host, token"
-)
 public class DatabricksCLITest {
 
     @Inject
     private RunContextFactory runContextFactory;
 
     @Test
+    @DisabledIf(
+        value = "canNotBeEnabled",
+        disabledReason = "Disabled for CI/CD as requires secrets data: host, token"
+    )
     void run() throws Exception {
         var databricksCLI = DatabricksCLI.builder()
             .id(IdUtils.create())
@@ -45,6 +46,61 @@ public class DatabricksCLITest {
         ScriptOutput output = databricksCLI.run(runContext);
 
         assertThat(output.getExitCode(), is(0));
+    }
+
+    @Test
+    void buildEnvPrefix_patOnly() {
+        var task = DatabricksCLI.builder()
+            .id(IdUtils.create())
+            .type(DatabricksCLI.class.getName())
+            .build();
+
+        var prefix = task.buildEnvPrefix("https://host.databricks.com", "my-token", null, null);
+
+        assertThat(prefix, containsString("DATABRICKS_TOKEN=my-token"));
+        assertThat(prefix, containsString("DATABRICKS_HOST=https://host.databricks.com"));
+        assertThat(prefix, not(containsString("DATABRICKS_CLIENT_ID")));
+        assertThat(prefix, not(containsString("DATABRICKS_CLIENT_SECRET")));
+    }
+
+    @Test
+    void buildEnvPrefix_oauthM2m() {
+        var task = DatabricksCLI.builder()
+            .id(IdUtils.create())
+            .type(DatabricksCLI.class.getName())
+            .build();
+
+        var prefix = task.buildEnvPrefix("https://host.databricks.com", null, "client-id", "client-secret");
+
+        assertThat(prefix, containsString("DATABRICKS_CLIENT_ID=client-id"));
+        assertThat(prefix, containsString("DATABRICKS_CLIENT_SECRET=client-secret"));
+        assertThat(prefix, containsString("DATABRICKS_HOST=https://host.databricks.com"));
+        assertThat(prefix, not(containsString("DATABRICKS_TOKEN")));
+    }
+
+    @Test
+    void buildEnvPrefix_tokenTakesPrecedenceOverOauth() {
+        var task = DatabricksCLI.builder()
+            .id(IdUtils.create())
+            .type(DatabricksCLI.class.getName())
+            .build();
+
+        var prefix = task.buildEnvPrefix("https://host.databricks.com", "my-token", "client-id", "client-secret");
+
+        assertThat(prefix, containsString("DATABRICKS_TOKEN=my-token"));
+        assertThat(prefix, not(containsString("DATABRICKS_CLIENT_ID")));
+        assertThat(prefix, not(containsString("DATABRICKS_CLIENT_SECRET")));
+    }
+
+    @Test
+    void buildEnvPrefix_neitherThrows() {
+        var task = DatabricksCLI.builder()
+            .id(IdUtils.create())
+            .type(DatabricksCLI.class.getName())
+            .build();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> task.buildEnvPrefix("https://host.databricks.com", null, null, null));
     }
 
     protected static boolean canNotBeEnabled() {


### PR DESCRIPTION
## Summary

- Removes `@NotNull` from `databricksToken`, making PAT optional
- Adds `clientId` and `clientSecret` properties for OAuth M2M service principal auth
- Extracts `buildEnvPrefix()` as a package-private helper that selects `DATABRICKS_TOKEN` vs `DATABRICKS_CLIENT_ID`/`DATABRICKS_CLIENT_SECRET`; PAT takes precedence when both are set; neither set throws `IllegalArgumentException`
- Moves `@DisabledIf` from class level to the container `run()` test only, so the four new `buildEnvPrefix` unit tests run in CI without any secrets
- Adds a third `@Example` showing OAuth M2M usage in the class Javadoc
- Adds a DatabricksCLI auth section to README.md

closes: https://github.com/kestra-io/plugin-databricks/issues/222

## Test plan

- [ ] `./gradlew test` passes — 4 new unit tests green, existing `run()` test skipped without secrets
- [ ] `./gradlew shadowJar` builds
- [ ] Manual: set `DATABRICKS_HOST` + `DATABRICKS_CLIENT_ID` + `DATABRICKS_CLIENT_SECRET` and run the OAuth example flow against a live workspace