### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/databricks/AbstractTask.java
+++ b/src/main/java/io/kestra/plugin/databricks/AbstractTask.java
@@ -83,21 +83,25 @@ public abstract class AbstractTask extends Task {
         private Property<String> authType;
 
         @Schema(title = "Databricks personal access token")
+        @PluginProperty(secret = true)
         private Property<String> token;
 
         @Schema(title = "Client ID")
         private Property<String> clientId;
 
         @Schema(title = "Client secret")
+        @PluginProperty(secret = true)
         private Property<String> clientSecret;
 
         @Schema(title = "Username")
         private Property<String> username;
 
         @Schema(title = "Password")
+        @PluginProperty(secret = true)
         private Property<String> password;
 
         @Schema(title = "Google credentials JSON")
+        @PluginProperty(secret = true)
         private Property<String> googleCredentials;
 
         @Schema(title = "Google service account email")
@@ -107,6 +111,7 @@ public abstract class AbstractTask extends Task {
         private Property<String> azureClientId;
 
         @Schema(title = "Azure client secret")
+        @PluginProperty(secret = true)
         private Property<String> azureClientSecret;
 
         @Schema(title = "Azure tenant ID")

--- a/src/main/java/io/kestra/plugin/databricks/cli/DatabricksSQLCLI.java
+++ b/src/main/java/io/kestra/plugin/databricks/cli/DatabricksSQLCLI.java
@@ -135,6 +135,8 @@ public class DatabricksSQLCLI extends Task implements RunnableTask<ScriptOutput>
 
         var renderedOutputFiles = runContext.render(this.outputFiles).asList(String.class);
 
+        String token = runContext.render(this.token).as(String.class).orElseThrow(() -> new IllegalArgumentException("Missing token"));
+
         List<String> databricksCommand = getDatabricksCommand(runContext);
 
         return new CommandsWrapper(runContext)
@@ -143,6 +145,7 @@ public class DatabricksSQLCLI extends Task implements RunnableTask<ScriptOutput>
             .withContainerImage("databricks-sql-cli")
             .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
             .withCommands(Property.ofValue(databricksCommand))
+            .withEnv(Map.of("DATABRICKS_TOKEN", token))
             .withInputFiles(inputFiles)
             .withOutputFiles(renderedOutputFiles.isEmpty() ? null : renderedOutputFiles)
             .run();
@@ -155,8 +158,7 @@ public class DatabricksSQLCLI extends Task implements RunnableTask<ScriptOutput>
         String host = runContext.render(this.host).as(String.class).orElseThrow(() -> new IllegalArgumentException("Missing host"));
         commandBuilder.append(" --hostname ").append(host);
 
-        String token = runContext.render(this.token).as(String.class).orElseThrow(() -> new IllegalArgumentException("Missing token"));
-        commandBuilder.append(" --access-token ").append(token);
+        commandBuilder.append(" --access-token $DATABRICKS_TOKEN");
 
         String httpPath = runContext.render(this.httpPath).as(String.class).orElseThrow(() -> new IllegalArgumentException("Missing http-path"));
         commandBuilder.append(" --http-path ").append(httpPath);


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** Multiple credential fields in AuthenticationConfig missing @PluginProperty(secret=true) (`src/main/java/io/kestra/plugin/databricks/AbstractTask.java:86`)
  - Fix: Added `@PluginProperty(secret = true)` to `token`, `clientSecret`, `password`, `googleCredentials`, and `azureClientSecret` fields in `AuthenticationConfig` so the Kestra UI and serialisation layer correctly mask these values.

- **HIGH** Databricks access token embedded in plain-text shell command string (`src/main/java/io/kestra/plugin/databricks/cli/DatabricksSQLCLI.java:159`)
  - Fix: Resolved the token in `run()` and passed it to `CommandsWrapper.withEnv()` as `DATABRICKS_TOKEN`; the command now references `$DATABRICKS_TOKEN` instead of embedding the secret value in the process argument list.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-databricks/issues/241
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
